### PR TITLE
[Doc fix] Fix a typo

### DIFF
--- a/content/en/docs/languages/go/basics.md
+++ b/content/en/docs/languages/go/basics.md
@@ -309,7 +309,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 In the method body we use the `RouteGuide_RecordRouteServer`'s `Recv()` method
 to repeatedly read in our client's requests to a request object (in this case a
 `Point`) until there are no more messages: the server needs to check the error
-returned from `Read()` after each call. If this is `nil`, the stream is still
+returned from `Recv()` after each call. If this is `nil`, the stream is still
 good and it can continue reading; if it's `io.EOF` the message stream has ended
 and the server can return its `RouteSummary`. If it has any other value, we
 return the error "as is" so that it'll be translated to an RPC status by the


### PR DESCRIPTION
Fix a typo -- there is no Read() call, as the document says